### PR TITLE
sqlite3 patch - handle uri filenames

### DIFF
--- a/db/src/SQLite3Connection.cpp
+++ b/db/src/SQLite3Connection.cpp
@@ -84,6 +84,8 @@ namespace db {
 	
 	void SQLite3Connection::open_db_connection( std::string const& filename, bool overwrite, std::string const& mode ) {
 		int flags = 0 ;
+		// Force uri filenames when SQLITE_USE_URI is not enabled during compilation
+		flags |= SQLITE_OPEN_URI ;
 		if( mode == "r" ) {
 			flags |= SQLITE_OPEN_READONLY ;
 		} else if( mode == "rw" ) {


### PR DESCRIPTION
- adds flag to handle uri filenames when sqlite not compiled with SQLITE_USE_URI
- removes dependency on custom built sqlite3 (3.9.2) - tested with (3.33 conda-forge)

static sqlite in legacy 3rd_party directory defined required flags:
- SQLITE_ENABLE_COLUMN_METADATA 
- SQLITE_ENABLE_STAT4 
- SQLITE_MAX_EXPR_DEPTH=10000
- SQLITE_USE_URI=1

from these SQLITE_ENABLE_COLUMN_METADATA and SQLITE_MAX_EXPR_DEPTH are already used in current [conda build for sqlite](https://github.com/conda-forge/sqlite-feedstock/blob/35f5c843a952bb6a265b8e27d6dd340c5d472765/recipe/build.sh). SQLITE_ENABLE_STAT4 seems to be for debugging (doesn't show effect if not enabled).

SQLITE_USE_URI which is necessary for rbgen can be enabled both in compile-time and run-time. Expecting difficulties to enforce it in conda setups (could cause issues to others), I apply patch to handle within rbgen. This gave the possibility to remove dependency on custom built sqlite3 (no need for conda-forge sqlite to be recompiled)